### PR TITLE
Expose Prisma Studio port (5555)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     ports:
       - "${PORT}:${PORT}"
       - "9229:9229"
+      - "5555:5555"
     volumes:
       - type: volume
         source: node_modules


### PR DESCRIPTION
Exposes port needed to run https://www.prisma.io/studio (`npx prisma studio`) using Docker.